### PR TITLE
More Values Permed

### DIFF
--- a/Receiver Project/files/src/Core/defs.h
+++ b/Receiver Project/files/src/Core/defs.h
@@ -32,7 +32,7 @@
 
 /******************************************************
  * Set the text that gets displayed to the user */
-#define SW_REVISION "X1.8.0"
+#define SW_REVISION "X1.8.1"
 
 //#define DEBUG_FUNCTIONS_ENABLE
 // #define TRANQUILIZE_WATCHDOG
@@ -66,7 +66,7 @@
 
 /******************************************************
  * EEPROM definitions */
-#define EEPROM_INITIALIZED_FLAG 0xA5
+#define EEPROM_INITIALIZED_FLAG 0xA6
 #define EEPROM_TONE_VOLUME_DEFAULT 5
 #define EEPROM_MAIN_VOLUME_DEFAULT 11
 

--- a/Receiver Project/files/src/Core/linkbus.h
+++ b/Receiver Project/files/src/Core/linkbus.h
@@ -109,7 +109,7 @@ typedef enum
 	MESSAGE_RSSI_REPEAT_BC = 'S' * 10 + 'S',		/* RSSI repeat broadcast toggle */
 	MESSAGE_RF_BC = 'R',                            /* RF level broadcast data */
 	MESSAGE_TEMPERATURE_BC = 'T',                   /* Temperature broadcast data */
-	MESSAGE_PERM = 'P',								/* Saves all settings to EEPROM "perm" */
+	MESSAGE_PERM = 'P',								/* Saves most settings to EEPROM "perm" */
 	MESSAGE_CW_OFFSET = 'O',						/* Sets or returns the CW offset in Hz */
 	MESSAGE_ATTENUATION = 'A',                      /* Sets receiver attenuation (0-255) */
 	MESSAGE_PREAMP = 'P' * 100 + 'R' * 10 + 'E',    /* Turn on preamp (1|0) */

--- a/Receiver Project/files/src/Core/receiver.h
+++ b/Receiver Project/files/src/Core/receiver.h
@@ -96,6 +96,11 @@ typedef enum
 #define RX_MINIMUM_80M_FREQUENCY 3500000
 #define RX_MAXIMUM_80M_FREQUENCY 4000000
 
+#define DEFAULT_PREAMP_80M 255;
+#define DEFAULT_PREAMP_2M 1;
+#define DEFAULT_ATTENUATION 0;
+
+
 typedef struct
 {
 /*	BatteryLevel battery; */
@@ -168,5 +173,22 @@ typedef enum
 /**
  */
 RadioBand bandForFrequency(Frequency_Hz freq);
+
+/**
+ */
+uint8_t rxSetPreamp(uint8_t setting);
+
+/**
+ */
+uint8_t rxGetPreamp(void);
+
+/**
+ */
+uint8_t rxSetAttenuation(uint8_t att);
+
+/**
+ */
+uint8_t rxGetAttenuation(void);
+
 
 #endif  /* RECEIVER_H_ */


### PR DESCRIPTION
o Includes attenuation, 2m preamp, and 80m preamp (VGA) settings to the
list of those that get "permed"
o Moved more receiver functionality to receiver.c module.
o Version X1.8.1